### PR TITLE
Fix missign check on index_sync for non-progressive tech

### DIFF
--- a/worlds/factorio_space_age/data/mod/control.lua
+++ b/worlds/factorio_space_age/data/mod/control.lua
@@ -564,11 +564,13 @@ commands.add_command("ap-get-technology", "Grant a technology, used by the Archi
     if force.technologies[item_name] ~= nil then
         local tech = force.technologies[item_name]
         if tech ~= nil then
-            storage.index_sync[index] = item_name
-            if tech.researched ~= true then
-                game.print({"", "Received [technology=" .. tech.name .. "] from ", source})
-                game.play_sound({path="utility/research_completed"})
-                tech.researched = true
+            if storage.index_sync[index] ~= item_name then -- not yet received tech
+                storage.index_sync[index] = item_name
+                if tech.researched ~= true then
+                    game.print({"", "Received [technology=" .. tech.name .. "] from ", source})
+                    game.play_sound({path="utility/research_completed"})
+                    tech.researched = true
+                end
             end
         end
     elseif TRAP_TABLE[item_name] ~= nil then


### PR DESCRIPTION
Add missing `storage.index_sync` check for non-progressive technologies.

This should fix https://github.com/thejoshwolfe/Archipelago/issues/28

The check is already missing in the base Factorio world but it doesn't matter there since unlocking the same tech multiple time does nothing outside of infinite techs.